### PR TITLE
自動ログインに必要な情報があるかチェックする

### DIFF
--- a/Development/udemy/OshiraseApp/src/screens/LoginScreen.js
+++ b/Development/udemy/OshiraseApp/src/screens/LoginScreen.js
@@ -15,6 +15,11 @@ class LoginScreen extends React.Component {
   async componentDidMount() {
     const email = await SecureStore.getItemAsync('email');
     const password = await SecureStore.getItemAsync('password');
+    if (email != null || password != null) {
+      this.setState({ isLoading: false });
+      return;
+    }
+    this.setState({ isLoading: true });
     firebase.auth().signInWithEmailAndPassword(email, password)
       .then(() => {
         this.setState({ isLoading: false });


### PR DESCRIPTION
### Fix
`getItemAsync` で取得できる情報がない場合、
空の状態でログインを試みてしまうのでローディング画面がずっと消えない。